### PR TITLE
Fix broken handling when receiving strings instead of DateObjects or Timestamps

### DIFF
--- a/SnipeSharp/Serialization/Converters/DateObjectConverter.cs
+++ b/SnipeSharp/Serialization/Converters/DateObjectConverter.cs
@@ -9,7 +9,13 @@ namespace SnipeSharp.Serialization.Converters
 
         public override DateTime? ReadJson(JsonReader reader, Type objectType, DateTime? existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            if(serializer.Deserialize<DateObjectResponse>(reader) is DateObjectResponse response && DateTime.TryParse(response.DateTime, out var datetime))
+            if(reader.TokenType == JsonToken.String)
+            {
+                // This is probably one of the broken API endpoints that returns the model directly
+                // instead of properly transforming it.
+                if(serializer.Deserialize<string>(reader) is string response && DateTime.TryParse(response, out var datetime))
+                    return datetime;
+            } else if(serializer.Deserialize<DateObjectResponse>(reader) is DateObjectResponse response && DateTime.TryParse(response.DateTime, out var datetime))
                 return datetime;
             return null;
         }

--- a/SnipeSharp/Serialization/Converters/TimestampConverter.cs
+++ b/SnipeSharp/Serialization/Converters/TimestampConverter.cs
@@ -9,7 +9,13 @@ namespace SnipeSharp.Serialization.Converters
 
         public override DateTime? ReadJson(JsonReader reader, Type objectType, DateTime? existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            if(serializer.Deserialize<TimestampResponse>(reader) is TimestampResponse response && DateTime.TryParse(response.DateTime, out var datetime))
+            if(reader.TokenType == JsonToken.String)
+            {
+                // This is probably one of the broken API endpoints that returns the model directly
+                // instead of properly transforming it.
+                if(serializer.Deserialize<string>(reader) is string response && DateTime.TryParse(response, out var datetime))
+                    return datetime;
+            } else if(serializer.Deserialize<TimestampResponse>(reader) is TimestampResponse response && DateTime.TryParse(response.DateTime, out var datetime))
                 return datetime;
             return null;
         }


### PR DESCRIPTION
In Snipe-IT, some endpoints -- especially for creating new objects and including the one for Assets -- don't properly transform the return object before returning it. This causes a conflict by which `DateObjectConverter` and `TimestampConverter` are expecting an object with some formatted strings, but instead directly receive a string.

This PR adds extra handling to both of these converters to check if a bare string was received instead of the proper object, and in that case parse it into a DateTime object.

Fixes #2. There is still an outstanding issue whereby duplicate asset tags are not causing the correct error message, but with Snipe-IT v5 coming out soon and my own work on actually implementing integration testing for this module, this is a low priority.